### PR TITLE
feat: Implement ExactSizeIterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rayon = ["dep:rayon", "dep:once_cell"]
 [dependencies]
 ndarray = { version = "0.15.4", features = ["serde"] }
 ndarray-rand = "0.14.0"
-itertools = "0.10.3"
+itertools = "0.11.0"
 rand = "0.8.5"
 tch = { version = "0.13.0", optional = true, features = ["download-libtorch"] }
 rayon = { version = "1.7.0", optional = true }
@@ -39,7 +39,6 @@ once_cell = { version = "1.17.1", optional = true }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 csv = "1.1.6"
 image = "0.24.3"
-itertools = "0.10.3"
 nshare = { version = "0.9.0", features = ["ndarray", "image"] }
 
 [[example]]

--- a/src/indexable/fetch/mod.rs
+++ b/src/indexable/fetch/mod.rs
@@ -23,7 +23,7 @@ where
     C: Collate<D::Sample>,
 {
     /// Given a batch of index, return the result of the collate function on them.
-    fn fetch(&mut self, possibly_batched_index: Vec<usize>) -> C::Output;
+    fn fetch(&self, possibly_batched_index: Vec<usize>) -> C::Output;
 }
 
 /// Fetcher for map-style dataset. Simply call the collate function on all the batch of elements.
@@ -45,7 +45,7 @@ where
     C: Collate<D::Sample>,
     D::Sample: Send,
 {
-    fn fetch(&mut self, possibly_batched_index: Vec<usize>) -> C::Output {
+    fn fetch(&self, possibly_batched_index: Vec<usize>) -> C::Output {
         // As the batch length can vary depending on if the last element is dropped or not, we can't use a fix len array to
         // collect the data.
         #[cfg(feature = "rayon")]

--- a/src/indexable/sampler/batch_sampler.rs
+++ b/src/indexable/sampler/batch_sampler.rs
@@ -98,16 +98,13 @@ where
         None
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let (lower, upper) = self.sampler.size_hint();
-        if self.drop_last {
-            let lower = lower / self.batch_size;
-            let upper = upper.map(|upper| upper / self.batch_size);
-            (lower, upper)
+        let (lower, _) = self.sampler.size_hint();
+        let lower = if self.drop_last {
+            lower / self.batch_size
         } else {
-            let lower = (lower + self.batch_size - 1) / self.batch_size;
-            let upper = upper.map(|upper| (upper + self.batch_size - 1) / self.batch_size);
-            (lower, upper)
-        }
+            (lower + self.batch_size - 1) / self.batch_size
+        };
+        (lower, Some(lower))
     }
 }
 

--- a/src/indexable/sampler/sequential_sampler.rs
+++ b/src/indexable/sampler/sequential_sampler.rs
@@ -22,22 +22,27 @@ impl Len for SequentialSampler {
     }
 }
 impl IntoIterator for SequentialSampler {
-    type IntoIter = Range<usize>;
     type Item = usize;
+    type IntoIter = Range<usize>;
     fn into_iter(self) -> Self::IntoIter {
         0..self.data_source_len
     }
 }
 
-#[test]
-fn sequential_sampler() {
-    let dataset = vec![1, 2, 3];
-    let sampler = SequentialSampler {
-        data_source_len: dataset.len(),
-    };
-    let mut iter = sampler.into_iter();
-    assert_eq!(iter.next(), Some(0));
-    assert_eq!(iter.next(), Some(1));
-    assert_eq!(iter.next(), Some(2));
-    assert_eq!(iter.next(), None);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sequential_sampler() {
+        let dataset = vec![1, 2, 3];
+        let sampler = SequentialSampler {
+            data_source_len: dataset.len(),
+        };
+        let mut iter = sampler.into_iter();
+        assert_eq!(iter.next(), Some(0));
+        assert_eq!(iter.next(), Some(1));
+        assert_eq!(iter.next(), Some(2));
+        assert_eq!(iter.next(), None);
+    }
 }

--- a/src/iterable/dataloader/mod.rs
+++ b/src/iterable/dataloader/mod.rs
@@ -96,16 +96,13 @@ where
         None
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let (lower, upper) = self.dataset_iter.size_hint();
-        if self.drop_last {
-            let lower = lower / self.batch_size;
-            let upper = upper.map(|upper| upper / self.batch_size);
-            (lower, upper)
+        let (lower, _) = self.dataset_iter.size_hint();
+        let lower = if self.drop_last {
+            lower / self.batch_size
         } else {
-            let lower = (lower + self.batch_size - 1) / self.batch_size;
-            let upper = upper.map(|upper| (upper + self.batch_size - 1) / self.batch_size);
-            (lower, upper)
-        }
+            (lower + self.batch_size - 1) / self.batch_size
+        };
+        (lower, Some(lower))
     }
 }
 


### PR DESCRIPTION
This PR includes: 
- Itertools update to version 0.11 (could be another PR) ->  1st commit
- change Fetch trait: Make fn fetch use &self instead of &mut self (could be another PR too) -> 2nd commit 
   This change is motivated mainly because get_sample need only &self
- Implement ExactSizeIterator for all iterator when possible -> This allow to get the size of the dataset/dataloader through the iterator -> 3rd commit